### PR TITLE
Swift SDK: Add session tracking with `SessionPlugin`

### DIFF
--- a/Sources/Hightouch/Analytics.swift
+++ b/Sources/Hightouch/Analytics.swift
@@ -65,6 +65,7 @@ public class Analytics {
         // provide our default state
         store.provide(state: System.defaultState(configuration: configuration, from: storage))
         store.provide(state: UserInfo.defaultState(from: storage))
+        store.provide(state: SessionInfo.defaultState(from: storage))
         
         storage.analytics = self
         

--- a/Sources/Hightouch/Configuration.swift
+++ b/Sources/Hightouch/Configuration.swift
@@ -103,6 +103,9 @@ public extension Configuration {
     /// - Returns: The current Configuration.
     @discardableResult
     func foregroundSessionTimeout(_ timeout: Int) -> Configuration {
+        guard SessionPluginHelper.isValidSessionTimeout(timeout) else {
+            fatalError("foregroundSessionTimeout must be greater than or equal to zero.")
+        }
         values.foregroundSessionTimeout = timeout
         return self
     }
@@ -114,6 +117,9 @@ public extension Configuration {
     /// - Returns: The current Configuration.
     @discardableResult
     func backgroundSessionTimeout(_ timeout: Int) -> Configuration {
+        guard SessionPluginHelper.isValidSessionTimeout(timeout) else {
+            fatalError("backgroundSessionTimeout must be greater than or equal to zero.")
+        }
         values.backgroundSessionTimeout = timeout
         return self
     }

--- a/Sources/Hightouch/Configuration.swift
+++ b/Sources/Hightouch/Configuration.swift
@@ -19,6 +19,8 @@ public class Configuration {
         var trackApplicationLifecycleEvents: Bool = true
         var flushAt: Int = 20
         var flushInterval: TimeInterval = 30
+        var foregroundSessionTimeout: Int = 1_800_000
+        var backgroundSessionTimeout: Int = 1_800_000
         var defaultSettings: Settings? = nil
         var autoAddSegmentDestination: Bool = true
         var apiHost: String = HTTPClient.getDefaultAPIHost()
@@ -91,6 +93,28 @@ public extension Configuration {
     @discardableResult
     func flushInterval(_ interval: TimeInterval) -> Configuration {
         values.flushInterval = interval
+        return self
+    }
+
+    /// Set the maximum foreground inactivity in milliseconds before starting a new session.
+    /// The default value is `1_800_000` (30 minutes). Set both session timeouts to `0` to disable sessions.
+    ///
+    /// - Parameter timeout: Timeout in milliseconds.
+    /// - Returns: The current Configuration.
+    @discardableResult
+    func foregroundSessionTimeout(_ timeout: Int) -> Configuration {
+        values.foregroundSessionTimeout = timeout
+        return self
+    }
+
+    /// Set the maximum background duration in milliseconds before starting a new session on resume.
+    /// The default value is `1_800_000` (30 minutes). Set both session timeouts to `0` to disable sessions.
+    ///
+    /// - Parameter timeout: Timeout in milliseconds.
+    /// - Returns: The current Configuration.
+    @discardableResult
+    func backgroundSessionTimeout(_ timeout: Int) -> Configuration {
+        values.backgroundSessionTimeout = timeout
         return self
     }
     

--- a/Sources/Hightouch/ObjC/ObjCConfiguration.swift
+++ b/Sources/Hightouch/ObjC/ObjCConfiguration.swift
@@ -60,6 +60,30 @@ public class ObjCConfiguration: NSObject {
             configuration.flushInterval(value)
         }
     }
+
+    /// Set the maximum foreground inactivity in milliseconds before starting a new session.
+    /// The default value is `1_800_000` (30 minutes). Set both session timeouts to `0` to disable sessions.
+    @objc
+    public var foregroundSessionTimeout: Int {
+        get {
+            return configuration.values.foregroundSessionTimeout
+        }
+        set(value) {
+            configuration.foregroundSessionTimeout(value)
+        }
+    }
+
+    /// Set the maximum background duration in milliseconds before starting a new session on resume.
+    /// The default value is `1_800_000` (30 minutes). Set both session timeouts to `0` to disable sessions.
+    @objc
+    public var backgroundSessionTimeout: Int {
+        get {
+            return configuration.values.backgroundSessionTimeout
+        }
+        set(value) {
+            configuration.backgroundSessionTimeout(value)
+        }
+    }
     
     /// Sets a default set of Settings.  Normally these will come from Segment's
     /// api.segment.com/v1/projects/<writekey>/settings, however in instances such

--- a/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
@@ -118,8 +118,9 @@ class SessionPlugin: PlatformPlugin, EventPlugin {
         guard let analytics = analytics else { return }
 
         analytics.store.dispatch(action: SessionInfo.UpdateSessionAction(update: update))
-        let sessionInfo: SessionInfo? = analytics.store.currentState()
-        analytics.storage.write(.sessionState, value: sessionInfo?.sessionState)
+        if let sessionInfo: SessionInfo = analytics.store.currentState() {
+            analytics.storage.write(.sessionState, value: sessionInfo.sessionState)
+        }
     }
 }
 

--- a/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
@@ -55,7 +55,7 @@ class SessionPlugin: PlatformPlugin, EventPlugin {
         updateSessionState { state in
             return SessionPluginHelper.rotateSession(state: state,
                                                      now: currentTime,
-                                                     firstEventId: state?.firstEventId ?? "",
+                                                     firstEventId: "",
                                                      firstEventTimestamp: Date(timeIntervalSince1970: TimeInterval(currentTime) / 1000).iso8601())
         }
     }

--- a/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPlugin.swift
@@ -1,0 +1,195 @@
+//
+//  SessionPlugin.swift
+//
+//
+//  Created by Cursor on 6/9/26.
+//
+
+import Foundation
+
+class SessionPlugin: PlatformPlugin, EventPlugin {
+    let type = PluginType.enrichment
+    weak var analytics: Analytics?
+
+    var now: () -> Int64 = {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private var isAppInBackground = false
+
+    func execute<T: RawEvent>(event: T?) -> T? {
+        guard let analytics = analytics, var workingEvent = event else {
+            return event
+        }
+
+        let currentTime = now()
+        let messageId = workingEvent.messageId ?? ""
+        let timestamp = workingEvent.timestamp ?? Date(timeIntervalSince1970: TimeInterval(currentTime) / 1000).iso8601()
+        let configuration = analytics.configuration.values
+        var contextSession: ContextSession?
+
+        updateSessionState { state in
+            let result = SessionPluginHelper.processEvent(state: state,
+                                                          now: currentTime,
+                                                          messageId: messageId,
+                                                          timestamp: timestamp,
+                                                          foregroundSessionTimeout: configuration.foregroundSessionTimeout,
+                                                          backgroundSessionTimeout: configuration.backgroundSessionTimeout,
+                                                          isAppInBackground: self.isAppInBackground)
+            contextSession = result.contextSession
+            return result.sessionState
+        }
+
+        guard let contextSession = contextSession else {
+            return workingEvent
+        }
+
+        workingEvent.context = addSessionContext(to: workingEvent.context, contextSession: contextSession)
+        return workingEvent
+    }
+
+    func reset() {
+        guard analytics != nil else { return }
+
+        let currentTime = now()
+        updateSessionState { state in
+            return SessionPluginHelper.rotateSession(state: state,
+                                                     now: currentTime,
+                                                     firstEventId: state?.firstEventId ?? "",
+                                                     firstEventTimestamp: Date(timeIntervalSince1970: TimeInterval(currentTime) / 1000).iso8601())
+        }
+    }
+
+    private func addSessionContext(to eventContext: JSON?, contextSession: ContextSession) -> JSON? {
+        var context = eventContext?.dictionaryValue ?? [:]
+        context.removeValue(forKey: "sessionStart")
+        context["session"] = sessionDictionary(from: contextSession)
+        context["sessionId"] = contextSession.sessionId
+        if contextSession.sessionStart == true {
+            context["sessionStart"] = true
+        }
+
+        return try? JSON(context)
+    }
+
+    private func sessionDictionary(from contextSession: ContextSession) -> [String: Any] {
+        var session: [String: Any] = [
+            "sessionId": contextSession.sessionId,
+            "sessionIndex": contextSession.sessionIndex,
+            "eventIndex": contextSession.eventIndex,
+            "previousSessionId": contextSession.previousSessionId.map { $0 as Any } ?? NSNull(),
+            "firstEventId": contextSession.firstEventId,
+            "firstEventTimestamp": contextSession.firstEventTimestamp
+        ]
+
+        if contextSession.sessionStart == true {
+            session["sessionStart"] = true
+        }
+
+        return session
+    }
+
+    private func markBackgrounded() {
+        guard analytics != nil else { return }
+        guard !isAppInBackground else { return }
+        isAppInBackground = true
+
+        let currentTime = now()
+        updateSessionState { state in
+            return SessionPluginHelper.markBackgrounded(state: state, now: currentTime)
+        }
+    }
+
+    private func markForegrounded() {
+        guard let analytics = analytics else { return }
+        guard isAppInBackground else { return }
+        isAppInBackground = false
+
+        let currentTime = now()
+        let backgroundSessionTimeout = analytics.configuration.values.backgroundSessionTimeout
+        updateSessionState { state in
+            return SessionPluginHelper.markForegrounded(state: state,
+                                                        now: currentTime,
+                                                        backgroundSessionTimeout: backgroundSessionTimeout)
+        }
+    }
+
+    private func updateSessionState(_ update: @escaping (SessionState?) -> SessionState?) {
+        guard let analytics = analytics else { return }
+
+        analytics.store.dispatch(action: SessionInfo.UpdateSessionAction(update: update))
+        let sessionInfo: SessionInfo? = analytics.store.currentState()
+        analytics.storage.write(.sessionState, value: sessionInfo?.sessionState)
+    }
+}
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+import UIKit
+
+extension SessionPlugin: iOSLifecycle {
+    func applicationWillResignActive(application: UIApplication?) {
+        markBackgrounded()
+    }
+
+    func applicationDidEnterBackground(application: UIApplication?) {
+        markBackgrounded()
+    }
+
+    func applicationWillEnterForeground(application: UIApplication?) {
+        markForegrounded()
+    }
+
+    func applicationDidBecomeActive(application: UIApplication?) {
+        markForegrounded()
+    }
+}
+#endif
+
+#if os(macOS)
+import Cocoa
+
+extension SessionPlugin: macOSLifecycle {
+    func applicationDidResignActive() {
+        markBackgrounded()
+    }
+
+    func applicationDidHide() {
+        markBackgrounded()
+    }
+
+    func applicationWillBecomeActive() {
+        markForegrounded()
+    }
+
+    func applicationDidBecomeActive() {
+        markForegrounded()
+    }
+
+    func applicationDidUnhide() {
+        markForegrounded()
+    }
+}
+#endif
+
+#if os(watchOS)
+import WatchKit
+
+extension SessionPlugin: watchOSLifecycle {
+    func applicationDidEnterBackground(watchExtension: WKExtension) {
+        markBackgrounded()
+    }
+
+    func applicationWillResignActive(watchExtension: WKExtension) {
+        markBackgrounded()
+    }
+
+    func applicationWillEnterForeground(watchExtension: WKExtension) {
+        markForegrounded()
+    }
+
+    func applicationDidBecomeActive(watchExtension: WKExtension) {
+        markForegrounded()
+    }
+}
+#endif
+

--- a/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
@@ -1,0 +1,168 @@
+//
+//  SessionPluginHelper.swift
+//
+//
+//  Created by Cursor on 6/9/26.
+//
+
+import Foundation
+
+struct ContextSession: Equatable {
+    let sessionId: Int64
+    let sessionIndex: Int
+    let sessionStart: Bool?
+    let eventIndex: Int
+    let previousSessionId: Int64?
+    let firstEventId: String
+    let firstEventTimestamp: String
+}
+
+struct EnrichedSessionEvent: Equatable {
+    let contextSession: ContextSession
+    let sessionState: SessionState
+}
+
+enum SessionPluginHelper {
+    static func isEnabled(foregroundSessionTimeout: Int, backgroundSessionTimeout: Int) -> Bool {
+        return !(foregroundSessionTimeout == 0 && backgroundSessionTimeout == 0)
+    }
+
+    static func isEnabled(_ config: Configuration.Values) -> Bool {
+        return isEnabled(foregroundSessionTimeout: config.foregroundSessionTimeout,
+                         backgroundSessionTimeout: config.backgroundSessionTimeout)
+    }
+
+    static func shouldRotateOnResume(state: SessionState?,
+                                     now: Int64,
+                                     backgroundSessionTimeout: Int = 0) -> Bool {
+        guard let backgroundedAt = state?.backgroundedAt, backgroundSessionTimeout > 0 else {
+            return false
+        }
+
+        return now - backgroundedAt > Int64(backgroundSessionTimeout)
+    }
+
+    static func shouldRotateOnInactivity(state: SessionState?,
+                                         now: Int64,
+                                         foregroundSessionTimeout: Int = 0) -> Bool {
+        guard let state = state, foregroundSessionTimeout > 0 else {
+            return false
+        }
+
+        return now - state.lastActivityAt > Int64(foregroundSessionTimeout)
+    }
+
+    static func rotateSession(state: SessionState?,
+                              now: Int64,
+                              firstEventId: String,
+                              firstEventTimestamp: String) -> SessionState {
+        return SessionState(sessionId: now,
+                            sessionIndex: state == nil ? 0 : state!.sessionIndex + 1,
+                            previousSessionId: state?.sessionId,
+                            firstEventId: firstEventId,
+                            firstEventTimestamp: firstEventTimestamp,
+                            eventIndex: 0,
+                            lastActivityAt: now,
+                            backgroundedAt: nil)
+    }
+
+    static func enrichEvent(state: SessionState,
+                            now: Int64,
+                            updateActivity: Bool = true) -> EnrichedSessionEvent {
+        let sessionStart = state.eventIndex == 0
+        let contextSession = ContextSession(sessionId: state.sessionId,
+                                            sessionIndex: state.sessionIndex,
+                                            sessionStart: sessionStart ? true : nil,
+                                            eventIndex: state.eventIndex,
+                                            previousSessionId: state.previousSessionId,
+                                            firstEventId: state.firstEventId,
+                                            firstEventTimestamp: state.firstEventTimestamp)
+        let sessionState = SessionState(sessionId: state.sessionId,
+                                        sessionIndex: state.sessionIndex,
+                                        previousSessionId: state.previousSessionId,
+                                        firstEventId: state.firstEventId,
+                                        firstEventTimestamp: state.firstEventTimestamp,
+                                        eventIndex: state.eventIndex + 1,
+                                        lastActivityAt: updateActivity ? now : state.lastActivityAt,
+                                        backgroundedAt: updateActivity ? nil : state.backgroundedAt)
+
+        return EnrichedSessionEvent(contextSession: contextSession, sessionState: sessionState)
+    }
+
+    static func ensureFirstEvent(state: SessionState,
+                                 messageId: String,
+                                 timestamp: String) -> SessionState {
+        if state.eventIndex != 0 || state.firstEventId != "" {
+            return state
+        }
+
+        return SessionState(sessionId: state.sessionId,
+                            sessionIndex: state.sessionIndex,
+                            previousSessionId: state.previousSessionId,
+                            firstEventId: messageId,
+                            firstEventTimestamp: timestamp,
+                            eventIndex: state.eventIndex,
+                            lastActivityAt: state.lastActivityAt,
+                            backgroundedAt: state.backgroundedAt)
+    }
+
+    static func processEvent(state: SessionState?,
+                             now: Int64,
+                             messageId: String,
+                             timestamp: String,
+                             foregroundSessionTimeout: Int = 0,
+                             backgroundSessionTimeout: Int = 0,
+                             isAppInBackground: Bool = false) -> EnrichedSessionEvent {
+        let shouldRotate = state == nil ||
+            (!isAppInBackground &&
+                (shouldRotateOnResume(state: state,
+                                      now: now,
+                                      backgroundSessionTimeout: backgroundSessionTimeout) ||
+                 shouldRotateOnInactivity(state: state,
+                                          now: now,
+                                          foregroundSessionTimeout: foregroundSessionTimeout)))
+
+        let currentState = shouldRotate
+            ? rotateSession(state: state, now: now, firstEventId: messageId, firstEventTimestamp: timestamp)
+            : ensureFirstEvent(state: state!, messageId: messageId, timestamp: timestamp)
+
+        return enrichEvent(state: currentState, now: now, updateActivity: !isAppInBackground)
+    }
+
+    static func markBackgrounded(state: SessionState?, now: Int64) -> SessionState? {
+        guard let state = state else {
+            return state
+        }
+
+        return SessionState(sessionId: state.sessionId,
+                            sessionIndex: state.sessionIndex,
+                            previousSessionId: state.previousSessionId,
+                            firstEventId: state.firstEventId,
+                            firstEventTimestamp: state.firstEventTimestamp,
+                            eventIndex: state.eventIndex,
+                            lastActivityAt: state.lastActivityAt,
+                            backgroundedAt: now)
+    }
+
+    static func markForegrounded(state: SessionState?,
+                                 now: Int64,
+                                 backgroundSessionTimeout: Int = 0) -> SessionState? {
+        guard let state = state else {
+            return state
+        }
+
+        if shouldRotateOnResume(state: state, now: now, backgroundSessionTimeout: backgroundSessionTimeout) {
+            return state
+        }
+
+        return SessionState(sessionId: state.sessionId,
+                            sessionIndex: state.sessionIndex,
+                            previousSessionId: state.previousSessionId,
+                            firstEventId: state.firstEventId,
+                            firstEventTimestamp: state.firstEventTimestamp,
+                            eventIndex: state.eventIndex,
+                            lastActivityAt: now,
+                            backgroundedAt: nil)
+    }
+}
+

--- a/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
@@ -23,6 +23,10 @@ struct EnrichedSessionEvent: Equatable {
 }
 
 enum SessionPluginHelper {
+    static func isValidSessionTimeout(_ timeout: Int) -> Bool {
+        return timeout >= 0
+    }
+
     static func isEnabled(foregroundSessionTimeout: Int, backgroundSessionTimeout: Int) -> Bool {
         return !(foregroundSessionTimeout == 0 && backgroundSessionTimeout == 0)
     }

--- a/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
+++ b/Sources/Hightouch/Plugins/Session/SessionPluginHelper.swift
@@ -145,7 +145,7 @@ enum SessionPluginHelper {
                             firstEventTimestamp: state.firstEventTimestamp,
                             eventIndex: state.eventIndex,
                             lastActivityAt: state.lastActivityAt,
-                            backgroundedAt: now)
+                            backgroundedAt: state.backgroundedAt ?? now)
     }
 
     static func markForegrounded(state: SessionState?,

--- a/Sources/Hightouch/Startup.swift
+++ b/Sources/Hightouch/Startup.swift
@@ -63,6 +63,10 @@ extension Analytics: Subscriber {
             //plugins.append(LinuxLifecycleMonitor())
             #endif
         }
+
+        if SessionPluginHelper.isEnabled(configuration.values) {
+            plugins.append(SessionPlugin())
+        }
         
         if plugins.isEmpty {
             return nil

--- a/Sources/Hightouch/State.swift
+++ b/Sources/Hightouch/State.swift
@@ -135,6 +135,31 @@ struct UserInfo: Codable, State {
     }
 }
 
+// MARK: - Session information
+
+struct SessionState: Codable, Equatable {
+    let sessionId: Int64
+    let sessionIndex: Int
+    let previousSessionId: Int64?
+    let firstEventId: String
+    let firstEventTimestamp: String
+    let eventIndex: Int
+    let lastActivityAt: Int64
+    let backgroundedAt: Int64?
+}
+
+struct SessionInfo: State {
+    let sessionState: SessionState?
+
+    struct UpdateSessionAction: Action {
+        let update: (SessionState?) -> SessionState?
+
+        func reduce(state: SessionInfo) -> SessionInfo {
+            return SessionInfo(sessionState: update(state.sessionState))
+        }
+    }
+}
+
 // MARK: - Default State Setup
 
 extension System {
@@ -167,5 +192,12 @@ extension UserInfo {
         }
 
         return UserInfo(anonymousId: anonymousId, userId: userId, traits: traits, referrer: nil)
+    }
+}
+
+extension SessionInfo {
+    static func defaultState(from storage: Storage) -> SessionInfo {
+        let sessionState: SessionState? = storage.read(.sessionState)
+        return SessionInfo(sessionState: sessionState)
     }
 }

--- a/Sources/Hightouch/Utilities/Storage.swift
+++ b/Sources/Hightouch/Utilities/Storage.swift
@@ -31,6 +31,9 @@ internal class Storage: Subscriber {
         store.subscribe(self) { [weak self] (state: System) in
             self?.systemUpdate(state: state)
         }
+        store.subscribe(self) { [weak self] (state: SessionInfo) in
+            self?.sessionInfoUpdate(state: state)
+        }
     }
     
     func write<T: Codable>(_ key: Storage.Constants, value: T?) {
@@ -172,6 +175,7 @@ extension Storage {
         case anonymousIdSegment = "segment.anonymousId"
         case anonymousIdRudder = "rl_anonymous_id"
         case settings = "hightouch.settings"
+        case sessionState = "hightouch.sessionState"
         case events = "hightouch.events"
     }
 }
@@ -191,6 +195,10 @@ extension Storage {
         if let s = state.settings {
             write(.settings, value: s)
         }
+    }
+
+    internal func sessionInfoUpdate(state: SessionInfo) {
+        write(.sessionState, value: state.sessionState)
     }
 }
 

--- a/Sources/Hightouch/Utilities/Storage.swift
+++ b/Sources/Hightouch/Utilities/Storage.swift
@@ -31,9 +31,6 @@ internal class Storage: Subscriber {
         store.subscribe(self) { [weak self] (state: System) in
             self?.systemUpdate(state: state)
         }
-        store.subscribe(self) { [weak self] (state: SessionInfo) in
-            self?.sessionInfoUpdate(state: state)
-        }
     }
     
     func write<T: Codable>(_ key: Storage.Constants, value: T?) {
@@ -197,9 +194,6 @@ extension Storage {
         }
     }
 
-    internal func sessionInfoUpdate(state: SessionInfo) {
-        write(.sessionState, value: state.sessionState)
-    }
 }
 
 // MARK: - Utility Methods

--- a/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
+++ b/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
@@ -1,0 +1,159 @@
+//
+//  SessionPluginHelper_Tests.swift
+//
+//
+//  Created by Cursor on 6/9/26.
+//
+
+import XCTest
+@testable import Hightouch
+
+final class SessionPluginHelper_Tests: XCTestCase {
+    private let initialState = SessionState(sessionId: 1000,
+                                            sessionIndex: 0,
+                                            previousSessionId: nil,
+                                            firstEventId: "first-message-id",
+                                            firstEventTimestamp: "2026-01-01T00:00:01.000Z",
+                                            eventIndex: 1,
+                                            lastActivityAt: 1000,
+                                            backgroundedAt: nil)
+
+    func testCreatesFirstSessionOnFirstEvent() {
+        let result = SessionPluginHelper.processEvent(state: nil,
+                                                      now: 1000,
+                                                      messageId: "message-id",
+                                                      timestamp: "2026-01-01T00:00:01.000Z",
+                                                      foregroundSessionTimeout: 1_800_000,
+                                                      backgroundSessionTimeout: 1_800_000)
+
+        XCTAssertEqual(result.contextSession,
+                       ContextSession(sessionId: 1000,
+                                      sessionIndex: 0,
+                                      sessionStart: true,
+                                      eventIndex: 0,
+                                      previousSessionId: nil,
+                                      firstEventId: "message-id",
+                                      firstEventTimestamp: "2026-01-01T00:00:01.000Z"))
+        XCTAssertEqual(result.sessionState,
+                       SessionState(sessionId: 1000,
+                                    sessionIndex: 0,
+                                    previousSessionId: nil,
+                                    firstEventId: "message-id",
+                                    firstEventTimestamp: "2026-01-01T00:00:01.000Z",
+                                    eventIndex: 1,
+                                    lastActivityAt: 1000,
+                                    backgroundedAt: nil))
+    }
+
+    func testIncrementsEventIndexWithinSession() {
+        let result = SessionPluginHelper.processEvent(state: initialState,
+                                                      now: 2000,
+                                                      messageId: "second-message-id",
+                                                      timestamp: "2026-01-01T00:00:02.000Z",
+                                                      foregroundSessionTimeout: 1_800_000,
+                                                      backgroundSessionTimeout: 1_800_000)
+
+        XCTAssertEqual(result.contextSession,
+                       ContextSession(sessionId: 1000,
+                                      sessionIndex: 0,
+                                      sessionStart: nil,
+                                      eventIndex: 1,
+                                      previousSessionId: nil,
+                                      firstEventId: "first-message-id",
+                                      firstEventTimestamp: "2026-01-01T00:00:01.000Z"))
+        XCTAssertEqual(result.sessionState.eventIndex, 2)
+        XCTAssertEqual(result.sessionState.lastActivityAt, 2000)
+    }
+
+    func testRotatesAfterForegroundInactivityExceedsTimeout() {
+        let result = SessionPluginHelper.processEvent(state: initialState,
+                                                      now: 3000,
+                                                      messageId: "new-session-message-id",
+                                                      timestamp: "2026-01-01T00:00:03.000Z",
+                                                      foregroundSessionTimeout: 1999,
+                                                      backgroundSessionTimeout: 1_800_000)
+
+        XCTAssertEqual(result.contextSession,
+                       ContextSession(sessionId: 3000,
+                                      sessionIndex: 1,
+                                      sessionStart: true,
+                                      eventIndex: 0,
+                                      previousSessionId: 1000,
+                                      firstEventId: "new-session-message-id",
+                                      firstEventTimestamp: "2026-01-01T00:00:03.000Z"))
+    }
+
+    func testRotatesOnFirstEventAfterLongBackgroundDuration() {
+        let backgroundedState = SessionState(sessionId: initialState.sessionId,
+                                             sessionIndex: initialState.sessionIndex,
+                                             previousSessionId: initialState.previousSessionId,
+                                             firstEventId: initialState.firstEventId,
+                                             firstEventTimestamp: initialState.firstEventTimestamp,
+                                             eventIndex: initialState.eventIndex,
+                                             lastActivityAt: initialState.lastActivityAt,
+                                             backgroundedAt: 1500)
+
+        let foregroundedState = SessionPluginHelper.markForegrounded(state: backgroundedState,
+                                                                     now: 4000,
+                                                                     backgroundSessionTimeout: 2000)
+        let result = SessionPluginHelper.processEvent(state: foregroundedState,
+                                                      now: 4000,
+                                                      messageId: "foreground-message-id",
+                                                      timestamp: "2026-01-01T00:00:04.000Z",
+                                                      foregroundSessionTimeout: 1_800_000,
+                                                      backgroundSessionTimeout: 2000)
+
+        XCTAssertEqual(result.contextSession,
+                       ContextSession(sessionId: 4000,
+                                      sessionIndex: 1,
+                                      sessionStart: true,
+                                      eventIndex: 0,
+                                      previousSessionId: 1000,
+                                      firstEventId: "foreground-message-id",
+                                      firstEventTimestamp: "2026-01-01T00:00:04.000Z"))
+    }
+
+    func testColdStartRotatesWhenPersistedBackgroundedAtExceeded() {
+        let backgroundedState = SessionState(sessionId: initialState.sessionId,
+                                             sessionIndex: initialState.sessionIndex,
+                                             previousSessionId: initialState.previousSessionId,
+                                             firstEventId: initialState.firstEventId,
+                                             firstEventTimestamp: initialState.firstEventTimestamp,
+                                             eventIndex: initialState.eventIndex,
+                                             lastActivityAt: initialState.lastActivityAt,
+                                             backgroundedAt: 1500)
+
+        let result = SessionPluginHelper.processEvent(state: backgroundedState,
+                                                      now: 4000,
+                                                      messageId: "cold-start-message-id",
+                                                      timestamp: "2026-01-01T00:00:04.000Z",
+                                                      foregroundSessionTimeout: 1_800_000,
+                                                      backgroundSessionTimeout: 2000)
+
+        XCTAssertEqual(result.contextSession.sessionId, 4000)
+        XCTAssertEqual(result.contextSession.sessionIndex, 1)
+        XCTAssertEqual(result.contextSession.previousSessionId, 1000)
+        XCTAssertEqual(result.contextSession.sessionStart, true)
+        XCTAssertEqual(result.contextSession.eventIndex, 0)
+    }
+
+    func testRotateSessionOnResetIncrementsSessionIndex() {
+        let result = SessionPluginHelper.rotateSession(state: initialState,
+                                                       now: 5000,
+                                                       firstEventId: initialState.firstEventId,
+                                                       firstEventTimestamp: "2026-01-01T00:00:05.000Z")
+
+        XCTAssertEqual(result.sessionId, 5000)
+        XCTAssertEqual(result.sessionIndex, 1)
+        XCTAssertEqual(result.previousSessionId, 1000)
+        XCTAssertEqual(result.eventIndex, 0)
+    }
+
+    func testIsEnabledOnlyFalseWhenBothTimeoutsAreZero() {
+        XCTAssertTrue(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 1, backgroundSessionTimeout: 0))
+        XCTAssertTrue(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 0, backgroundSessionTimeout: 1))
+        XCTAssertTrue(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 1, backgroundSessionTimeout: 1))
+        XCTAssertFalse(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 0, backgroundSessionTimeout: 0))
+    }
+}
+

--- a/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
+++ b/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
@@ -149,6 +149,12 @@ final class SessionPluginHelper_Tests: XCTestCase {
         XCTAssertEqual(result.eventIndex, 0)
     }
 
+    func testRejectsNegativeSessionTimeouts() {
+        XCTAssertFalse(SessionPluginHelper.isValidSessionTimeout(-1))
+        XCTAssertTrue(SessionPluginHelper.isValidSessionTimeout(0))
+        XCTAssertTrue(SessionPluginHelper.isValidSessionTimeout(1_800_000))
+    }
+
     func testIsEnabledOnlyFalseWhenBothTimeoutsAreZero() {
         XCTAssertTrue(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 1, backgroundSessionTimeout: 0))
         XCTAssertTrue(SessionPluginHelper.isEnabled(foregroundSessionTimeout: 0, backgroundSessionTimeout: 1))

--- a/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
+++ b/Tests/Hightouch-Tests/SessionPluginHelper_Tests.swift
@@ -113,6 +113,41 @@ final class SessionPluginHelper_Tests: XCTestCase {
                                       firstEventTimestamp: "2026-01-01T00:00:04.000Z"))
     }
 
+    func testPreservesBackgroundedAtWhenRebackgroundingWithPendingRotation() {
+        let backgroundedState = SessionState(sessionId: initialState.sessionId,
+                                             sessionIndex: initialState.sessionIndex,
+                                             previousSessionId: initialState.previousSessionId,
+                                             firstEventId: initialState.firstEventId,
+                                             firstEventTimestamp: initialState.firstEventTimestamp,
+                                             eventIndex: initialState.eventIndex,
+                                             lastActivityAt: initialState.lastActivityAt,
+                                             backgroundedAt: 1500)
+
+        let foregroundedState = SessionPluginHelper.markForegrounded(state: backgroundedState,
+                                                                     now: 4000,
+                                                                     backgroundSessionTimeout: 2000)
+        XCTAssertEqual(foregroundedState?.backgroundedAt, 1500)
+
+        let rebackgroundedState = SessionPluginHelper.markBackgrounded(state: foregroundedState, now: 5100)
+        XCTAssertEqual(rebackgroundedState?.backgroundedAt, 1500)
+
+        let result = SessionPluginHelper.processEvent(state: rebackgroundedState,
+                                                      now: 5200,
+                                                      messageId: "delayed-rotation-message-id",
+                                                      timestamp: "2026-01-01T00:00:05.200Z",
+                                                      foregroundSessionTimeout: 1_800_000,
+                                                      backgroundSessionTimeout: 2000)
+
+        XCTAssertEqual(result.contextSession,
+                       ContextSession(sessionId: 5200,
+                                      sessionIndex: 1,
+                                      sessionStart: true,
+                                      eventIndex: 0,
+                                      previousSessionId: 1000,
+                                      firstEventId: "delayed-rotation-message-id",
+                                      firstEventTimestamp: "2026-01-01T00:00:05.200Z"))
+    }
+
     func testColdStartRotatesWhenPersistedBackgroundedAtExceeded() {
         let backgroundedState = SessionState(sessionId: initialState.sessionId,
                                              sessionIndex: initialState.sessionIndex,

--- a/Tests/Hightouch-Tests/Session_Tests.swift
+++ b/Tests/Hightouch-Tests/Session_Tests.swift
@@ -86,7 +86,9 @@ final class Session_Tests: XCTestCase {
         XCTAssertEqual(number(session?["sessionIndex"]), 1)
         XCTAssertEqual(session?["sessionStart"] as? Bool, true)
         XCTAssertEqual(number(session?["previousSessionId"]), 1000)
-        XCTAssertEqual(session?["firstEventId"] as? String, (output.events[0] as? TrackEvent)?.messageId)
+        let firstEventId = session?["firstEventId"] as? String
+        XCTAssertNotEqual(firstEventId, "")
+        XCTAssertEqual(firstEventId, (output.events[1] as? TrackEvent)?.messageId)
     }
 
     func testDoesNotEnrichWhenBothTimeoutsAreZero() {

--- a/Tests/Hightouch-Tests/Session_Tests.swift
+++ b/Tests/Hightouch-Tests/Session_Tests.swift
@@ -263,6 +263,39 @@ final class Session_Tests: XCTestCase {
     }
     #endif
 
+    func testUploadsTrackedEventsWithSessionContext() throws {
+        let writeKey = "test-session-delivery"
+        resetStorage(writeKey: writeKey)
+        let analytics = Analytics(configuration: Configuration(writeKey: writeKey)
+            .trackApplicationLifecycleEvents(false)
+            .foregroundSessionTimeout(1_800_000)
+            .backgroundSessionTimeout(1_800_000))
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "Purchase Completed")
+
+        guard let urls = analytics.storage.read(.events) as? [URL], let url = urls.first else {
+            XCTFail("Expected event batch file")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []) as! [String: Any]
+        let batch = json["batch"] as! [[String: Any]]
+        let context = batch[0]["context"] as! [String: Any]
+        let session = context["session"] as! [String: Any]
+
+        XCTAssertEqual(number(context["sessionId"]), 1000)
+        XCTAssertEqual(context["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session["sessionId"]), 1000)
+        XCTAssertEqual(number(session["sessionIndex"]), 0)
+        XCTAssertEqual(session["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session["eventIndex"]), 0)
+        XCTAssertTrue(session["previousSessionId"] is NSNull)
+        XCTAssertNotNil(session["firstEventId"] as? String)
+    }
+
     private func makeAnalytics(writeKey suffix: String) -> Analytics {
         let writeKey = "test-\(suffix)"
         resetStorage(writeKey: writeKey)

--- a/Tests/Hightouch-Tests/Session_Tests.swift
+++ b/Tests/Hightouch-Tests/Session_Tests.swift
@@ -1,0 +1,312 @@
+//
+//  Session_Tests.swift
+//
+//
+//  Created by Cursor on 6/9/26.
+//
+
+import XCTest
+import Sovran
+@testable import Hightouch
+
+final class Session_Tests: XCTestCase {
+    func testAddsSessionContextToEveryEvent() {
+        let analytics = makeAnalytics(writeKey: "session-context")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 1500 }
+        analytics.track(name: "Second Event")
+
+        let firstContext = context(at: 0, output: output)
+        let firstSession = firstContext["session"] as? [String: Any]
+        XCTAssertEqual(number(firstContext["sessionId"]), 1000)
+        XCTAssertEqual(firstContext["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(firstSession?["sessionId"]), 1000)
+        XCTAssertEqual(number(firstSession?["sessionIndex"]), 0)
+        XCTAssertEqual(firstSession?["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(firstSession?["eventIndex"]), 0)
+        XCTAssertTrue(firstSession?["previousSessionId"] is NSNull)
+        XCTAssertEqual(firstSession?["firstEventId"] as? String, (output.events[0] as? TrackEvent)?.messageId)
+        XCTAssertEqual(firstSession?["firstEventTimestamp"] as? String, (output.events[0] as? TrackEvent)?.timestamp)
+
+        let secondContext = context(at: 1, output: output)
+        let secondSession = secondContext["session"] as? [String: Any]
+        XCTAssertEqual(number(secondContext["sessionId"]), 1000)
+        XCTAssertNil(secondContext["sessionStart"])
+        XCTAssertEqual(number(secondSession?["eventIndex"]), 1)
+        XCTAssertNil(secondSession?["sessionStart"])
+    }
+
+    func testRotatesAfterForegroundInactivity() {
+        let analytics = makeAnalytics(writeKey: "session-foreground-rotation")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 3001 }
+        analytics.track(name: "Rotated Event")
+
+        let eventContext = context(at: 1, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(eventContext["sessionId"]), 3001)
+        XCTAssertEqual(eventContext["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session?["sessionId"]), 3001)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+        XCTAssertEqual(number(session?["eventIndex"]), 0)
+    }
+
+    func testRotatesWhenResetIsCalled() {
+        let analytics = makeAnalytics(writeKey: "session-reset")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 5000 }
+        analytics.reset()
+        analytics.track(name: "After Reset")
+
+        let eventContext = context(at: 1, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 5000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(session?["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+        XCTAssertEqual(session?["firstEventId"] as? String, (output.events[0] as? TrackEvent)?.messageId)
+    }
+
+    func testDoesNotEnrichWhenBothTimeoutsAreZero() {
+        let writeKey = "session-disabled"
+        let storage = Storage(store: Store(), writeKey: writeKey)
+        storage.hardReset(doYouKnowHowToUseThis: true)
+
+        let analytics = Analytics(configuration: Configuration(writeKey: writeKey)
+            .autoAddSegmentDestination(false)
+            .trackApplicationLifecycleEvents(false)
+            .foregroundSessionTimeout(0)
+            .backgroundSessionTimeout(0))
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "No Session Event")
+
+        XCTAssertNil(analytics.find(pluginType: SessionPlugin.self))
+        XCTAssertNil((output.lastEvent as? TrackEvent)?.context?.dictionaryValue?["session"])
+        XCTAssertNil((output.lastEvent as? TrackEvent)?.context?.dictionaryValue?["sessionId"])
+    }
+
+    func testPersistsSessionStateAcrossAnalyticsInstances() {
+        let writeKey = "session-persistence"
+        resetStorage(writeKey: writeKey)
+
+        var analytics: Analytics? = Analytics(configuration: Configuration(writeKey: writeKey)
+            .autoAddSegmentDestination(false)
+            .trackApplicationLifecycleEvents(false)
+            .foregroundSessionTimeout(2000)
+            .backgroundSessionTimeout(2000))
+        var output = OutputReaderPlugin()
+        analytics?.add(plugin: output)
+        var plugin = configuredSessionPlugin(from: analytics!)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics?.track(name: "First Event")
+
+        analytics = nil
+
+        let nextAnalytics = Analytics(configuration: Configuration(writeKey: writeKey)
+            .autoAddSegmentDestination(false)
+            .trackApplicationLifecycleEvents(false)
+            .foregroundSessionTimeout(2000)
+            .backgroundSessionTimeout(2000))
+        output = OutputReaderPlugin()
+        nextAnalytics.add(plugin: output)
+        plugin = configuredSessionPlugin(from: nextAnalytics)
+        plugin.now = { 1500 }
+        waitUntilStarted(analytics: nextAnalytics)
+        nextAnalytics.track(name: "Second Event")
+
+        let eventContext = context(at: 0, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 1000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 0)
+        XCTAssertEqual(number(session?["eventIndex"]), 1)
+        XCTAssertNil(session?["sessionStart"])
+    }
+
+    #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    func testRotatesAfterBackgroundTimeout() {
+        let analytics = makeAnalytics(writeKey: "session-background-rotation")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 1500 }
+        plugin.applicationWillResignActive(application: nil)
+
+        plugin.now = { 4000 }
+        plugin.applicationDidBecomeActive(application: nil)
+        analytics.track(name: "Foreground Event")
+
+        let eventContext = context(at: 1, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 4000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+        XCTAssertEqual(session?["sessionStart"] as? Bool, true)
+    }
+
+    func testPreservesBackgroundTimestampWhenEventsAreProcessedWhileBackgrounded() {
+        let analytics = makeAnalytics(writeKey: "session-background-event")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 1500 }
+        plugin.applicationWillResignActive(application: nil)
+
+        plugin.now = { 1501 }
+        analytics.track(name: "Application Backgrounded")
+
+        plugin.now = { 4000 }
+        plugin.applicationDidBecomeActive(application: nil)
+        analytics.track(name: "Foreground Event")
+
+        let eventContext = context(at: 2, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 4000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(session?["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session?["eventIndex"]), 0)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+    }
+    #endif
+
+    #if os(macOS)
+    func testRotatesAfterBackgroundTimeout() {
+        let analytics = makeAnalytics(writeKey: "session-background-rotation")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 1500 }
+        plugin.applicationDidResignActive()
+
+        plugin.now = { 4000 }
+        plugin.applicationDidBecomeActive()
+        analytics.track(name: "Foreground Event")
+
+        let eventContext = context(at: 1, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 4000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+        XCTAssertEqual(session?["sessionStart"] as? Bool, true)
+    }
+
+    func testPreservesBackgroundTimestampWhenEventsAreProcessedWhileBackgrounded() {
+        let analytics = makeAnalytics(writeKey: "session-background-event")
+        let output = OutputReaderPlugin()
+        analytics.add(plugin: output)
+        let plugin = configuredSessionPlugin(from: analytics)
+
+        plugin.now = { 1000 }
+        waitUntilStarted(analytics: analytics)
+        analytics.track(name: "First Event")
+
+        plugin.now = { 1500 }
+        plugin.applicationDidResignActive()
+
+        plugin.now = { 1501 }
+        analytics.track(name: "Application Backgrounded")
+
+        plugin.now = { 4000 }
+        plugin.applicationDidBecomeActive()
+        analytics.track(name: "Foreground Event")
+
+        let eventContext = context(at: 2, output: output)
+        let session = eventContext["session"] as? [String: Any]
+        XCTAssertEqual(number(session?["sessionId"]), 4000)
+        XCTAssertEqual(number(session?["sessionIndex"]), 1)
+        XCTAssertEqual(session?["sessionStart"] as? Bool, true)
+        XCTAssertEqual(number(session?["eventIndex"]), 0)
+        XCTAssertEqual(number(session?["previousSessionId"]), 1000)
+    }
+    #endif
+
+    private func makeAnalytics(writeKey suffix: String) -> Analytics {
+        let writeKey = "test-\(suffix)"
+        resetStorage(writeKey: writeKey)
+        let analytics = Analytics(configuration: Configuration(writeKey: writeKey)
+            .autoAddSegmentDestination(false)
+            .trackApplicationLifecycleEvents(false)
+            .foregroundSessionTimeout(2000)
+            .backgroundSessionTimeout(2000))
+        return analytics
+    }
+
+    private func resetStorage(writeKey: String) {
+        let storage = Storage(store: Store(), writeKey: writeKey)
+        storage.hardReset(doYouKnowHowToUseThis: true)
+    }
+
+    private func configuredSessionPlugin(from analytics: Analytics) -> SessionPlugin {
+        guard let plugin = analytics.find(pluginType: SessionPlugin.self) else {
+            XCTFail("Expected SessionPlugin to be registered")
+            return SessionPlugin()
+        }
+        return plugin
+    }
+
+    private func context(at index: Int, output: OutputReaderPlugin) -> [String: Any] {
+        guard output.events.indices.contains(index),
+              let context = output.events[index].context?.dictionaryValue else {
+            XCTFail("Expected event context at index \(index)")
+            return [:]
+        }
+        return context
+    }
+
+    private func number(_ value: Any?) -> Int64? {
+        switch value {
+        case let value as Int64:
+            return value
+        case let value as Int:
+            return Int64(value)
+        case let value as NSNumber:
+            return value.int64Value
+        case let value as Decimal:
+            return NSDecimalNumber(decimal: value).int64Value
+        default:
+            return nil
+        }
+    }
+}
+


### PR DESCRIPTION
## Overview
Add session tracking with configurable foreground & background timeouts.

## Changes
- Introduce `SessionPlugin` + `SessionPluginHelper` to manage session state and context for events
- Add `session` object to `event.context` with the following shape:
```swift
struct ContextSession: Equatable {
    let sessionId: Int64
    let sessionIndex: Int
    let sessionStart: Bool?
    let eventIndex: Int
    let previousSessionId: Int64?
    let firstEventId: String
    let firstEventTimestamp: String
}
```
- Also add `sessionId` and `sessionStart` to the base `event.context` object for parity with the JS SDK.
- Add configurable foreground and background session timeouts, with the ability to disable session tracking altogether by setting both to 0.

## Testing
1. Open `Examples/apps/BasicExample/BasicExample.xcworkspace` in Xcode
2. In `Examples/apps/BasicExample/BasicExample/AppDelegate.swift`, replace `<WRITE_KEY>` with the write key of an iOS source
3. Select a simulator in the scheme toolbar, and choose the `BasicExample` scheme if it isn’t already selected
4. Run with ⌘R
5. Perform actions in the example app, and verify that the events show up in the source's Debugger page with the new session tracking data:

<img width="1141" height="943" alt="Screenshot 2026-06-10 at 10 10 39 AM" src="https://github.com/user-attachments/assets/d31a681d-28e4-491a-b958-cbdcad4d1232" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic session tracking enriches all tracked events with session identifiers and metadata
  * Session state persists across app restarts and resets
  * Sessions automatically rotate based on inactivity and app background/foreground transitions

* **Configuration**
  * Added `foregroundSessionTimeout(_:)` configuration method (default: 30 minutes)
  * Added `backgroundSessionTimeout(_:)` configuration method (default: 30 minutes)
  * Set both timeouts to 0 to disable session tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->